### PR TITLE
Use default lsyncd settings

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,10 +1,6 @@
 class lsyncd::params {
   $config_dir  = '/etc/lsyncd'
   $config_file = 'lsyncd.conf.lua'
-  $settings = {
-    'logfile'    => '/var/log/lsyncd.log',
-    'statusFile' => '/var/log/lsyncd.status',
-    'insist'     => true,
-  }
+  $settings = {}
   $max_user_watches = undef
 }


### PR DESCRIPTION
Specifically:
- Log to syslog, not a file
- Don't write out status
- Don't insistently restart failing processes
