### PR TITLE
Force management of the lsyncd config dir.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,7 +7,10 @@ class lsyncd (
 ) inherits lsyncd::params {
 
   file { [$config_dir, "${config_dir}/sync.d"]:
-    ensure => 'directory',
+    ensure  => 'directory',
+    recurse => true,
+    purge   => true,
+    notify  => Service['lsyncd'],
   }
 
   file { "${config_dir}/dodir.lua":

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "negz-lsyncd",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": "Nic Cope",
   "license": "Apache-2.0",
   "summary": "Yet another lsyncd module",


### PR DESCRIPTION
This should ensure any stale configs added by this Puppet module are deleted. Conversely it means the content of `sync.d` **must** be managed by Puppet.
