### PR TITLE
make lsyncd delete-option configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ lsyncd::rsync:
 # Deletions
 
 "[By default](https://axkibe.github.io/lsyncd/manual/config/layer4/#deletions) Lsyncd will delete files on the target that are not present at the source".
-If you need to divert from this behaviour, set one of the other possible flags (delete|startup|running).
+If you need to divert from this behaviour, set one of the other possible flags (false|startup|running).
 
 ```yaml
     source: /tmp/source

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ lsyncd::rsync:
 
 # Deletions
 
-"[By default](https://axkibe.github.io/lsyncd/manual/config/layer4/) Lsyncd will delete files on the target that are not present at the source".
-If you need to divert from this behaviour, set one of the possible flags.
+"[By default](https://axkibe.github.io/lsyncd/manual/config/layer4/#deletions) Lsyncd will delete files on the target that are not present at the source".
+If you need to divert from this behaviour, set one of the other possible flags (delete|startup|running).
 
 ```yaml
     source: /tmp/source

--- a/README.md
+++ b/README.md
@@ -22,5 +22,16 @@ lsyncd::rsync:
       archive: true
 ```
 
+# Deletions
+
+"[By default](https://axkibe.github.io/lsyncd/manual/config/layer4/) Lsyncd will delete files on the target that are not present at the source".
+If you need to divert from this behaviour, set one of the possible flags.
+
+```yaml
+    source: /tmp/source
+    target: /tmp/target
+    delete: false
+```
+
 # Alternatives
 You might prefer [this lsyncd module](https://github.com/spjmurray/puppet-lsyncd) for Ubuntu, or [this one](https://github.com/thias/puppet-lsyncd) for RHEL.

--- a/manifests/rsync.pp
+++ b/manifests/rsync.pp
@@ -3,6 +3,7 @@ define lsyncd::rsync (
   $source   = undef,
   $target   = undef,
   $ensure   = present,
+  $delete   = true,
   $options  = {},
 ) {
   lsyncd::sync::rsync{$name:

--- a/manifests/sync/rsync.pp
+++ b/manifests/sync/rsync.pp
@@ -2,6 +2,7 @@ define lsyncd::sync::rsync (
   $source   = undef,
   $target   = undef,
   $ensure   = present,
+  $delete   = true,
   $options  = {},
 ) {
   $path = "${lsyncd::config_dir}/sync.d/${name}.conf.lua"

--- a/manifests/sync/rsyncssh.pp
+++ b/manifests/sync/rsyncssh.pp
@@ -3,6 +3,7 @@ define lsyncd::sync::rsyncssh (
   $targetdir,
   $host,
   $ensure         = present,
+  $delete         = true,
   $rsync_options  = {},
   $ssh_options    = {},
 ) {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "negz-lsyncd",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "author": "Nic Cope",
   "license": "Apache-2.0",
   "summary": "Yet another lsyncd module",

--- a/templates/rsync.conf.lua.erb
+++ b/templates/rsync.conf.lua.erb
@@ -2,7 +2,7 @@ sync {
   default.rsync,
   source = "<%= @source %>",
   target = "<%= @target %>",
-  delete = "<%= @delete %>",
+  delete = <%= @delete %>,
   rsync = {
     <% @options.each do |key, val| -%>
       <%= key %> = <%= val %>,

--- a/templates/rsync.conf.lua.erb
+++ b/templates/rsync.conf.lua.erb
@@ -2,6 +2,7 @@ sync {
   default.rsync,
   source = "<%= @source %>",
   target = "<%= @target %>",
+  delete = "<%= @delete %>",
   rsync = {
     <% @options.each do |key, val| -%>
       <%= key %> = <%= val %>,

--- a/templates/rsync.conf.lua.erb
+++ b/templates/rsync.conf.lua.erb
@@ -2,8 +2,12 @@ sync {
   default.rsync,
   source = "<%= @source %>",
   target = "<%= @target %>",
-  <%- if @delete == false -%>
+  <%- if @delete != true -%>
+    <%- if @delete == false -%>
   delete = <%= @delete %>,
+    <%- else -%>
+  delete = "<%= @delete %>",
+    <%- end -%>
   <%- end -%>
   rsync = {
     <% @options.each do |key, val| -%>

--- a/templates/rsync.conf.lua.erb
+++ b/templates/rsync.conf.lua.erb
@@ -2,7 +2,9 @@ sync {
   default.rsync,
   source = "<%= @source %>",
   target = "<%= @target %>",
+  <%- if @delete == false -%>
   delete = <%= @delete %>,
+  <%- end -%>
   rsync = {
     <% @options.each do |key, val| -%>
       <%= key %> = <%= val %>,

--- a/templates/rsyncssh.conf.lua.erb
+++ b/templates/rsyncssh.conf.lua.erb
@@ -2,7 +2,9 @@ sync {
   default.rsyncssh,
   source = "<%= @source %>",
   targetdir = "<%= @targetdir %>",
+  <%- if @delete == false -%>
   delete = <%= @delete %>,
+  <%- end -%>
   host = "<%= @host %>",
   rsync = {
     <% @rsync_options.each do |key, val| -%>

--- a/templates/rsyncssh.conf.lua.erb
+++ b/templates/rsyncssh.conf.lua.erb
@@ -2,7 +2,7 @@ sync {
   default.rsyncssh,
   source = "<%= @source %>",
   targetdir = "<%= @targetdir %>",
-  delete = "<%= @delete %>",
+  delete = <%= @delete %>,
   host = "<%= @host %>",
   rsync = {
     <% @rsync_options.each do |key, val| -%>

--- a/templates/rsyncssh.conf.lua.erb
+++ b/templates/rsyncssh.conf.lua.erb
@@ -2,6 +2,7 @@ sync {
   default.rsyncssh,
   source = "<%= @source %>",
   targetdir = "<%= @targetdir %>",
+  delete = "<%= @delete %>",
   host = "<%= @host %>",
   rsync = {
     <% @rsync_options.each do |key, val| -%>

--- a/templates/rsyncssh.conf.lua.erb
+++ b/templates/rsyncssh.conf.lua.erb
@@ -2,8 +2,12 @@ sync {
   default.rsyncssh,
   source = "<%= @source %>",
   targetdir = "<%= @targetdir %>",
-  <%- if @delete == false -%>
+  <%- if @delete != true -%>
+    <%- if @delete == false -%>
   delete = <%= @delete %>,
+    <%- else -%>
+  delete = "<%= @delete %>",
+    <%- end -%>
   <%- end -%>
   host = "<%= @host %>",
   rsync = {


### PR DESCRIPTION
This change makes the delete option of [lsyncd](https://axkibe.github.io/lsyncd/manual/config/layer4/#deletions) configurable. As mentioned in the doc "many users requested exceptions for this, for various reasons".

My specific use-case is in compiled asset-files that can exist on an appserver, but not on the orchestrating masternode. Syncing the directory from the master as source gives me flexibility nonetheless - working around webapp limitations/browser caching effects and having current and old assetfiles.

You can see results of testing the false and startup option [here](https://hastebin.com/upafexogoy). I'll need the false option mostly.

I had some difficulties to decide on proper indenting of the delete parameter in the .erb templates, if you have any suggestions I'd be thankful. For now I decided to cause no changes for existing configurations.